### PR TITLE
fix: QRコード一覧画面でベッド番号未設定の患者がいると画面がクラッシュするバグを修正

### DIFF
--- a/src/components/QrCodeListPage.js
+++ b/src/components/QrCodeListPage.js
@@ -175,7 +175,12 @@ const QrCodeListPage = ({ patients, onBack }) => {
         {/* フィルタリングされた患者リストを描画 */}
         {filteredPatients.length > 0 ? (
             filteredPatients
-            .sort((a, b) => a.bed.localeCompare(b.bed, undefined, { numeric: true })) // ベッド番号でソート
+            // ▼ ここを修正: bedが未定義の場合に備えて空文字("")をフォールバックとして使用します
+            .sort((a, b) => {
+                const bedA = a.bed || "";
+                const bedB = b.bed || "";
+                return bedA.localeCompare(bedB, undefined, { numeric: true });
+            })
             .map(patient => (
                 // patientIdが存在する場合のみQRコードを生成
                 patient.patientId && (


### PR DESCRIPTION
患者をベッド番号順にソートする際、新規患者などで`bed`プロパティがundefinedやnullの場合に`localeCompare`が実行できずレンダリングエラーとなる問題が発生していたため。 ソート時に`bed`が未定義の場合は空文字("")を使用するようにフォールバック処理を追加。